### PR TITLE
Add members data, grid include, JS and styles

### DIFF
--- a/_data/members.yml
+++ b/_data/members.yml
@@ -1,0 +1,39 @@
+- name: Andreas Angourakis
+  affiliation: Ruhr University Bochum and University of Cologne
+  role: coordinator
+  image: https://archaeologie.phil-fak.uni-koeln.de/sites/archaeologie/_processed_/8/c/csm_AngourakisAndreas_4154f9904d.jpg
+  website: https://orcid.org/0000-0002-9946-8142
+  bio: >
+    Computational archaeologist with a strong background in humanities and social sciences, specialising in simulating socioecological systems from the past. His main concern is to tackle meaningful theoretical questions about human behaviour and social institutions and their role in the biosphere, as documented by history and archaeology. His research focuses specifically on how social behaviour reflects long-term historical processes, especially those concerning food systems in past small-scale societies.
+
+- name: Dries Daems
+  affiliation: Vrije Universiteit Amsterdam
+  role: coordinator
+  image: https://www.driesdaems.com/author/dries-daems/avatar_hu3c610bb41e40063029d91f0079148825_78913_270x270_fill_q90_lanczos_center.jpg
+  website: https://www.driesdaems.com/
+  bio: >
+    Archaeologist specializing in the Iron Age to Hellenistic Mediterranean. His research interests include social complexity, urbanism, connectivity and information exchange, artisanal production, and human-environment interactions through computational modeling and pottery studies. He is currently Assistant Professor at VU Amsterdam and Visiting Professor at Helsinki University. He has held positions at KU Leuven, Koç University, and Middle East Technical University.
+
+- name: Philip Verhagen
+  affiliation: Vrije Universiteit Amsterdam
+  role: coordinator
+  image: https://research.vu.nl/files-asset/133529866/Philip_Verhagen_bw.jpg?w=160&f=webp
+  website: https://research.vu.nl/en/persons/philip-verhagen/
+  bio: >
+    associate professor at the Faculty of Social Science and Humanities, Vrije Universiteit Amsterdam, specialized in computer applications and quantitative methods in archaeology, with an emphasis on GIS, spatial analysis and modelling. He has been Publication Officer of Computer Applications and Quantitative Methods from 2011-2016, and is currently Managing Editor of the Journal of Computer Applications in Archaeology. Since 1 January 2018, dr. Verhagen is Scientific Director of ARCHON, the Dutch Research School for Archaeology.
+
+- name: Iza Romanowska
+  affiliation: Aarhus University
+  role: coordinator
+  image: https://ipure8.au.dk/current/photos/de64c8e8-dfc4-4769-a157-fdbf252a96d3-new.jpg
+  website: https://www.au.dk/en/iromanowska@cas.au.dk
+  bio: >
+    Associate Professor at the Social Resilience Lab, Center for Humanities Computing, Aarhus University.
+
+- name: Clemens Schmid
+  affiliation: Max Planck Institute for Evolutionary Anthropology
+  role: coordinator
+  image: https://www.eva.mpg.de/fileadmin/content_files/staff-images/clemens_schmid.jpg
+  website: https://archaeologie.phil-fak.uni-koeln.de/de/personen/schmid-clemens
+  bio: >
+    Researcher specialised on computational methods for the integrated, large-scale, and primarily spatio-temporal analysis of archaeological, ancient genomic, and linguistic data. He is currently working between the Departments of Archaeogenetics and Linguistic and Cultural Evolution at the Max Planck Institute for Evolutionary Anthropology in Leipzig (Germany).

--- a/_includes/member-grid.html
+++ b/_includes/member-grid.html
@@ -1,0 +1,118 @@
+{% assign roles = include.roles | default: "coordinator,contributor,member" | split: "," %}
+{% assign display_photos = include.display_photos | default: "coordinators" %}
+{% assign default_photo = include.default_photo | default: "/assets/images/members/default.jpg" %}
+
+<div class="member-controls mb-4 text-center">
+
+  <button class="btn btn-sm btn-outline-secondary mr-2"
+          onclick="toggleAllBios(true)">
+    Show all bios
+  </button>
+
+  <button class="btn btn-sm btn-outline-secondary mr-3"
+          onclick="toggleAllBios(false)">
+    Hide all bios
+  </button>
+
+  <select class="form-control d-inline-block w-auto"
+          onchange="filterByInstitution(this.value)">
+    <option value="all">All institutions</option>
+    {% assign institutions = site.data.members | map: "affiliation" | uniq | sort %}
+    {% for inst in institutions %}
+      <option value="{{ inst | slugify }}">{{ inst }}</option>
+    {% endfor %}
+  </select>
+
+</div>
+
+<div>
+{% for role in roles %}
+
+  {% assign group = site.data.members | where: "role", role | sort: "name" %}
+
+  {% if group.size > 0 %}
+
+    <h3 class="mt-5">{{ role | capitalize }}s</h3>
+
+    {% assign current_letter = "" %}
+
+    <div class="container mt-4">
+      <div class="row">
+
+        {% for person in group %}
+
+          {% assign first_letter = person.name | slice: 0,1 | upcase %}
+
+          {% if role != "coordinator" and first_letter != current_letter %}
+            {% assign current_letter = first_letter %}
+            <div class="col-12">
+              <h4 class="alphabet-header mt-4">{{ current_letter }}</h4>
+            </div>
+          {% endif %}
+
+          <div class="col-md-4 mb-4 member-entry"
+               data-institution="{{ person.affiliation | slugify }}">
+
+            <div class="member-card text-center">
+
+              {% assign show_photo = false %}
+
+              {% if display_photos == "all" %}
+                {% assign show_photo = true %}
+              {% elsif display_photos == "coordinators" and role == "coordinator" %}
+                {% assign show_photo = true %}
+              {% endif %}
+
+              {% if show_photo %}
+                {% if person.image %}
+                  {% assign photo = person.image %}
+                {% else %}
+                  {% assign photo = default_photo %}
+                {% endif %}
+
+                <img src="{{ photo }}"
+                     class="member-photo mb-3"
+                     alt="{{ person.name }}">
+              {% endif %}
+
+              <h5>
+                {% if person.website %}
+                  <a href="{{ person.website }}" target="_blank">
+                    {{ person.name }}
+                  </a>
+                {% else %}
+                  {{ person.name }}
+                {% endif %}
+              </h5>
+
+              <p class="text-muted">{{ person.affiliation }}</p>
+
+              {% if person.bio %}
+                <p>
+                  <a class="btn btn-sm btn-outline-secondary"
+                     data-toggle="collapse"
+                     href="#bio-{{ role }}-{{ forloop.index }}"
+                     role="button">
+                    Short bio
+                  </a>
+                </p>
+
+                <div class="collapse bio-collapse"
+                     id="bio-{{ role }}-{{ forloop.index }}">
+                  <div class="card card-body text-left">
+                    {{ person.bio }}
+                  </div>
+                </div>
+              {% endif %}
+
+            </div>
+          </div>
+
+        {% endfor %}
+
+      </div>
+    </div>
+
+  {% endif %}
+{% endfor %}
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,6 +13,31 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   </head>
 
+  <script>
+  function toggleAllBios(show) {
+    var bios = document.querySelectorAll('.bio-collapse');
+    bios.forEach(function(bio) {
+      if (show) {
+        bio.classList.add('show');
+      } else {
+        bio.classList.remove('show');
+      }
+    });
+  }
+
+  function filterByInstitution(value) {
+    var entries = document.querySelectorAll('.member-entry');
+    entries.forEach(function(entry) {
+      if (value === "all") {
+        entry.style.display = "";
+      } else {
+        entry.style.display =
+          entry.dataset.institution === value ? "" : "none";
+      }
+    });
+  }
+  </script>
+
   <body>
 
     {% include header.html %}

--- a/about-us.md
+++ b/about-us.md
@@ -2,6 +2,8 @@
 layout: default
 title: "About"
 permalink: /about
+display_photos: coordinators   # all | coordinators | none
+default_photo: /assets/images/Logo_noText.png
 ---
 # Who are we?
 
@@ -16,6 +18,14 @@ The targets of this network are:
 5. create a structure for international collaboration resulting in joint publications within the network.
 
 Join us at nassaabm@googlegroups.com (Google Groups) or by contacting [Andreas Angourakis](andros.spica@gmail.com).
+
+## Coordination and membership
+
+{% include member-grid.html
+   display_photos=page.display_photos
+   default_photo=page.default_photo %}
+
+## Institutional memberships
 
 Research units currently active in NASSA are:
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -278,3 +278,25 @@ nav ul li a .menu-title
 }
 
 #forkme_banner{ display: none !important; }
+
+.member-photo {
+  width: 150px;
+  height: 150px;
+  object-fit: cover;
+  border-radius: 50%;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+}
+
+.member-card {
+  padding: 1rem;
+  transition: transform 0.2s ease;
+}
+
+.member-card:hover {
+  transform: translateY(-4px);
+}
+
+.alphabet-header {
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 0.3rem;
+}


### PR DESCRIPTION
Add a new members dataset and a reusable member grid include to render member lists with photos, bios and institution filtering. Introduce toggleAllBios and filterByInstitution JS in the default layout to support show/hide bios and institution-based filtering. Update about-us.md to embed the member grid and set display/default photo options. Add styles for member photos, cards and alphabet headers to improve presentation. Possibility of using other roles (contributor, member) still pending.